### PR TITLE
Add contact page with staff grid layout, as seen in the design protot…

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -44,11 +44,18 @@ const Header = ({}) => {
                   display='flex'
                   flexDirection='column'
                 >
-                  <Box>
-                    <Link to='/'>
-                      <Text textAlign='center'>Homepage</Text>
-                    </Link>
-                  </Box>
+                  <Stack spaceY={4}>
+                    <Box>
+                      <Link to='/'>
+                        <Text textAlign='center'>Homepage</Text>
+                      </Link>
+                    </Box>
+                    <Box>
+                      <Link to='/contact'>
+                        <Text textAlign='center'>Contact Page</Text>
+                      </Link>
+                    </Box>
+                  </Stack>
                   {/*This is for everything at the bottom*/}
                   <Box flexGrow={1}/>
                   <Box m={4}>

--- a/src/constants/Staff.js
+++ b/src/constants/Staff.js
@@ -1,0 +1,6 @@
+export const  Staff =[
+  { name: "Krista Wallace", email: "kriswall@umbc.edu" },
+  { name: "Krista Wallace", email: "kriswall@umbc.edu" },
+  { name: "Krista Wallace", email: "kriswall@umbc.edu" },
+  { name: "Krista Wallace", email: "kriswall@umbc.edu" }
+]

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter } from 'react-router'
 import Homepage from './views/Homepage/Homepage'
 import StaffLoginPage from './views/StaffLoginPage/StaffLoginPage'
+import ContactPage from './views/ContactPage/ContactPage'
 import DefaultLayout from './views/DefaultLayout'
 
 const Router = createBrowserRouter([
@@ -15,6 +16,10 @@ const Router = createBrowserRouter([
       {
         path: 'login',
         element: <StaffLoginPage/>
+      },
+      {
+        path: 'contact',
+        element: <ContactPage/>
       }
     ]
   },

--- a/src/views/ContactPage/ContactPage.jsx
+++ b/src/views/ContactPage/ContactPage.jsx
@@ -1,0 +1,51 @@
+import { Box, Card, Grid, GridItem, Stack, Text } from "@chakra-ui/react"
+
+const ContactPage = () => {
+  const staffMembers = [
+    { name: "Krista Wallace", email: "kriswall@umbc.edu" },
+    { name: "Krista Wallace", email: "kriswall@umbc.edu" },
+    { name: "Krista Wallace", email: "kriswall@umbc.edu" },
+    { name: "Krista Wallace", email: "kriswall@umbc.edu" }
+  ]
+
+  return (
+    <Stack
+      width='100%'
+      minHeight='calc(100vh - 96px)'
+      bgColor='default'
+      alignItems='center'
+      p={8}
+    >
+      <Text fontSize={48} fontWeight='bold' color='black'>
+        Pre-Transfer Staff
+      </Text>
+      
+      <Grid templateColumns='repeat(2, 1fr)' gap={8} maxWidth='1200px' width='100%'>
+        {staffMembers.map((staff, index) => (
+          <GridItem key={index}>
+            <Card.Root
+              variant='elevated'
+              bgColor='primary'
+              textAlign='center'
+              p={6}
+            >
+              <Card.Body>
+                <Stack spaceY={2}>
+                  <Text fontSize={24} fontWeight='bold' color='black'>
+                    {staff.name}
+                  </Text>
+                  <Text fontSize={18} color='black'>
+                    {staff.email}
+                  </Text>
+                </Stack>
+              </Card.Body>
+            </Card.Root>
+          </GridItem>
+        ))}
+      </Grid>
+    </Stack>
+  )
+}
+
+export default ContactPage
+

--- a/src/views/ContactPage/ContactPage.jsx
+++ b/src/views/ContactPage/ContactPage.jsx
@@ -1,17 +1,10 @@
-import { Box, Card, Grid, GridItem, Stack, Text } from "@chakra-ui/react"
+import { Card, Grid, GridItem, Stack, Text } from "@chakra-ui/react"
+import { Staff } from "../../constants/staff"
 
 const ContactPage = () => {
-  const staffMembers = [
-    { name: "Krista Wallace", email: "kriswall@umbc.edu" },
-    { name: "Krista Wallace", email: "kriswall@umbc.edu" },
-    { name: "Krista Wallace", email: "kriswall@umbc.edu" },
-    { name: "Krista Wallace", email: "kriswall@umbc.edu" }
-  ]
-
   return (
     <Stack
       width='100%'
-      minHeight='calc(100vh - 96px)'
       bgColor='default'
       alignItems='center'
       p={8}
@@ -19,9 +12,8 @@ const ContactPage = () => {
       <Text fontSize={48} fontWeight='bold' color='black'>
         Pre-Transfer Staff
       </Text>
-      
       <Grid templateColumns='repeat(2, 1fr)' gap={8} maxWidth='1200px' width='100%'>
-        {staffMembers.map((staff, index) => (
+        {Staff.map((staff, index) => (
           <GridItem key={index}>
             <Card.Root
               variant='elevated'


### PR DESCRIPTION
…ype. Currently it simply has the name, and email of a singular pre-transfer advisor repeated. Will add more later, and will seek clarification if images of the advisors are needed